### PR TITLE
Fix CalendarsService::deleteCalendarById

### DIFF
--- a/src/Services/CalendarsService.php
+++ b/src/Services/CalendarsService.php
@@ -424,7 +424,7 @@ class CalendarsService extends Component
 
             $affectedRows = \Craft::$app->db
                 ->createCommand()
-                ->delete('calendar_calendars', ['id' => $calendarId])
+                ->delete(CalendarRecord::TABLE, ['id' => $calendarId])
                 ->execute();
 
             if ($transaction !== null) {


### PR DESCRIPTION
Replace hardcoded calendars table 'calendar_calendars' by CalendarRecord::TABLE in Fix CalendarsService::deleteCalendarById method