### PR TITLE
Ignore "all" filter on calendarId

### DIFF
--- a/src/Elements/Db/EventQuery.php
+++ b/src/Elements/Db/EventQuery.php
@@ -129,6 +129,16 @@ class EventQuery extends ElementQuery implements \Countable
         parent::__construct($elementType, $config);
     }
 
+    public function __set($propertyName, $value)
+    {
+        if ($propertyName === 'calendarId' && $value === '*') {
+            // Ignore the "all" value
+            return;
+        }
+
+        parent::__set($propertyName, $value);
+    }
+
     /**
      * @param int|array $value
      *

--- a/src/Elements/Event.php
+++ b/src/Elements/Event.php
@@ -177,8 +177,8 @@ class Event extends Element implements \JsonSerializable
             $propertyAccessor = new PropertyAccessor();
 
             foreach ($config as $key => $value) {
-                if ($propertyAccessor->isWritable($query, $key)) {
-                    $propertyAccessor->setValue($query, $key, $value);
+                if ($value && $propertyAccessor->isWritable($query, $key)) {
+                    $query->$key = $value;
                 }
             }
         }


### PR DESCRIPTION
When using PostgreSQL, and configuring the `UpcomingEventsWidget` to show all calendars, the following error is logged:

```
Error Info: Array
(
    [0] => 42883
    [1] => 7
    [2] => ERROR:  operator does not exist: integer ~~ unknown
LINE 9: WHERE (calendar_events."calendarId" LIKE $1) AND ((calendar_...
                                            ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
```

Relevant SQL:

```sql
SELECT "elements"."id"
FROM (SELECT "elements"."id" AS "elementsId", "elements_sites"."id" AS "elementsSitesId", "content"."id" AS "contentId"
FROM "elements" "elements"
INNER JOIN "calendar_events" "calendar_events" ON "calendar_events"."id" = "elements"."id"
INNER JOIN "elements_sites" "elements_sites" ON "elements_sites"."elementId" = "elements"."id"
INNER JOIN "content" "content" ON "content"."elementId" = "elements"."id"
INNER JOIN "calendar_calendars" ON "calendar_calendars"."id" = calendar_events."calendarId"
INNER JOIN "users" ON "users"."id" = calendar_events."authorId"
WHERE (calendar_events."calendarId" LIKE '%') AND ((calendar_events."rrule" IS NULL AND calendar_events."endDate" >= '2019-04-02 04:48:09')
OR (calendar_events."rrule" IS NOT NULL AND calendar_events."until" IS NOT NULL AND calendar_events."until" >= '2019-04-02 04:48:09')
OR (calendar_events."rrule" IS NOT NULL AND calendar_events."until" IS NULL)
OR (calendar_events."freq" = 'SELECT_DATES')) AND ("elements_sites"."siteId"=1) AND ("content"."siteId"=1) AND ("elements"."archived"=FALSE) AND ("elements"."enabled"=TRUE) AND ("elements"."dateDeleted" IS NULL) AND ("elements_sites"."enabled"=TRUE)
ORDER BY "startDate") "subquery"
INNER JOIN "calendar_events" "calendar_events" ON "calendar_events"."id" = "subquery"."elementsId"
INNER JOIN "elements" "elements" ON "elements"."id" = "subquery"."elementsId"
INNER JOIN "elements_sites" "elements_sites" ON "elements_sites"."id" = "subquery"."elementsSitesId"
INNER JOIN "content" "content" ON "content"."id" = "subquery"."contentId"
INNER JOIN "calendar_calendars" ON "calendar_calendars"."id" = calendar_events."calendarId"
INNER JOIN "users" ON "users"."id" = calendar_events."authorId"
ORDER BY "startDate"
```

Psql doesn't allow `LIKE` statements on integer columns. A solution is to simply remove the filter if the `calendarId` value is `"*"`.

To that end, I've added a magic method on `EventQuery` to ignore `calendarId` instances when all calendars should be selected.

`PropertyAccessor::setValue` seems to bypass class magic methods. So I've removed the call to setValue and instead set the value directly on the object itself.