### PR TITLE
fix: wrong relational query

### DIFF
--- a/src/Records/CalendarRecord.php
+++ b/src/Records/CalendarRecord.php
@@ -39,6 +39,6 @@ class CalendarRecord extends ActiveRecord
      */
     public function getFieldLayout()
     {
-        return $this->hasOne(FieldLayout::class, ['fieldLayoutId' => 'id']);
+        return $this->hasOne(FieldLayout::class, ['id' => 'fieldLayoutId']);
     }
 }


### PR DESCRIPTION
This PR solves the following issue 

![Screenshot 2019-05-27 at 16 05 23](https://user-images.githubusercontent.com/32835435/58425168-74d55380-8099-11e9-9e19-32f91c61a26c.png)

This happens when you try to get the related fieldLayouts from the calendarInstance

```
use Solspace\Calendar\Records\CalendarRecord;
$calendar = CalendarRecord::find()->one();
$layout = $calendar->getFieldLayout();
```
