### PR TITLE
Fixed a bug related to asset bundles rendering multiple times

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -136,7 +136,7 @@ class Calendar extends Plugin
             \Craft::$app->view->registerTwigExtension($extension);
         }
 
-        if (\Craft::$app->request->isCpRequest) {
+        if (\Craft::$app->request->isCpRequest && !\Craft::$app->request->isActionRequest) {
             \Craft::$app->view->registerAssetBundle(MainAssetBundle::class);
         }
     }


### PR DESCRIPTION
Fixed a bug related to asset bundles rendering multiple times when Modals are opened in circumstances where the native 'View' class has been extended within a Module.

If the following definition is added to the 'config/app' file I am able to extend the native 'View' functionality:

```
return [
  components' => [
    'view' => [
      'class' => 'modules\<my-module>\models\<my-class>',
    ]
  ...
],
```

It doesn't matter what `<my-class>` does, simply extending `\craft\web\View` is the catalyst that has revealed the bug that has been fixed in this commit.

`class <my-class> extends \craft\web\View  { ... }`

The following causes an issue where the Asset Bundle is re-registered when opening modals throughout the CMS:

```
if (\Craft::$app->request->isCpRequest) {
   \Craft::$app->view->registerAssetBundle(MainAssetBundle::class);
}
```
And thus throws a Javascript error in the console:

`Uncaught (in promise) TypeError: Cannot read property 'displayError' of undefined at Craft.js?v=1583827556:2749`

Adding an additional (`!\Craft::$app->request->isActionRequest`) condition before registering the bundle resolves this bug.