### PR TITLE
fix: save selectDates in element afterSave

### DIFF
--- a/packages/plugin/src/Bundles/ExternalPluginSupport/FeedMe/CalendarIntegration.php
+++ b/packages/plugin/src/Bundles/ExternalPluginSupport/FeedMe/CalendarIntegration.php
@@ -69,16 +69,6 @@ if (class_exists('craft\feedme\base\Element')) {
                     }
                 }
             );
-
-            Event::on(
-                Process::class,
-                Process::EVENT_STEP_AFTER_ELEMENT_SAVE,
-                function (FeedProcessEvent $event) {
-                    if (EventElement::class === $event->feed['elementType']) {
-                        $this->_onAfterElementSave($event);
-                    }
-                }
-            );
         }
 
         public function getGroups()
@@ -203,8 +193,8 @@ if (class_exists('craft\feedme\base\Element')) {
 
         protected function parseSelectDates($feedData, $fieldInfo)
         {
-            $value = $this->fetchArrayValue($feedData, $fieldInfo);
-            $this->selectDates = $value;
+            // TODO convert dates to Carbon objects
+            return $this->fetchArrayValue($feedData, $fieldInfo);
         }
 
         private function _parseDate($feedData, $fieldInfo)
@@ -274,14 +264,6 @@ if (class_exists('craft\feedme\base\Element')) {
                 $element->rrule = $rrule->rfcString();
             } else {
                 $element->rrule = null;
-            }
-        }
-
-        private function _onAfterElementSave($event)
-        {
-            if (\count($this->selectDates)) {
-                $EventElement = EventElement::find()->id($event->element->id)->one();
-                Calendar::getInstance()->selectDates->saveDates($EventElement, $this->selectDates);
             }
         }
     }

--- a/packages/plugin/src/Controllers/EventsController.php
+++ b/packages/plugin/src/Controllers/EventsController.php
@@ -247,6 +247,12 @@ class EventsController extends BaseController
             }
         }
 
+        if ($event->repeatsOnSelectDates()) {
+            $event->selectDates = $transformer->getSelectDates();
+        } else {
+            $event->selectDates = [];
+        }
+
         // Save the entry (finally!)
         if ($event->enabled && $event->enabledForSite) {
             $event->setScenario(Element::SCENARIO_LIVE);
@@ -257,12 +263,6 @@ class EventsController extends BaseController
 
             $exceptions = $transformer->getExceptions();
             $this->getExceptionsService()->saveExceptions($event, $exceptions);
-
-            $selectDates = [];
-            if ($event->repeatsOnSelectDates()) {
-                $selectDates = $transformer->getSelectDates();
-            }
-            Calendar::getInstance()->selectDates->saveDates($event, $selectDates);
 
             // Return JSON response if the request is an AJAX request
             if (\Craft::$app->request->isAjax) {

--- a/packages/plugin/src/Controllers/LegacyEventsController.php
+++ b/packages/plugin/src/Controllers/LegacyEventsController.php
@@ -156,6 +156,12 @@ class LegacyEventsController extends EventsController
         $event->slug = \Craft::$app->request->post('slug', $event->slug);
         $event->setFieldValuesFromRequest('fields');
 
+        if ($event->repeatsOnSelectDates()) {
+            $event->selectDates = $values['selectDates'] ?? [];
+        } else {
+            $event->selectDates = [];
+        }
+
         // Save the entry (finally!)
         if ($event->enabled && $event->enabledForSite) {
             $event->setScenario(Element::SCENARIO_LIVE);
@@ -166,12 +172,6 @@ class LegacyEventsController extends EventsController
 
             $exceptions = $values['exceptions'] ?? [];
             $this->getExceptionsService()->saveExceptions($event, $exceptions);
-
-            $selectDates = [];
-            if ($event->repeatsOnSelectDates()) {
-                $selectDates = $values['selectDates'] ?? [];
-            }
-            Calendar::getInstance()->selectDates->saveDates($event, $selectDates);
 
             // Return JSON response if the request is an AJAX request
             if (\Craft::$app->request->isAjax) {

--- a/packages/plugin/src/Services/SelectDatesService.php
+++ b/packages/plugin/src/Services/SelectDatesService.php
@@ -105,26 +105,6 @@ class SelectDatesService extends Component
         return $dateStrings;
     }
 
-    /**
-     * @param Carbon[] $dates
-     */
-    public function saveDates(Event $event, array $dates)
-    {
-        \Craft::$app->db
-            ->createCommand()
-            ->delete(SelectDateRecord::TABLE, ['eventId' => $event->id])
-            ->execute()
-    ;
-
-        foreach ($dates as $date) {
-            $selectDateRecord = new SelectDateRecord();
-            $selectDateRecord->eventId = $event->id;
-            $selectDateRecord->date = $date;
-
-            $selectDateRecord->save();
-        }
-    }
-
     public function removeDate(Event $event, \DateTime $date)
     {
         $records = SelectDateRecord::findAll(


### PR DESCRIPTION
Fixes #88

I moved the logic for saving select dates to `Element::afterSave()` so that it's run consistently before after save events.

I think this should help reduce duplicate logic as well.

In order to do this I had to modify the the Event element to allow "setting" the select dates without saving them,
which seems a bit messy, but I'm unaware of a more correct approach.

I'm not sure how to modify the FeedMe integration so I added a TODO there