### PR TITLE
Adds PHP 8.1 compatibility

### DIFF
--- a/packages/plugin/src/Elements/Db/EventQuery.php
+++ b/packages/plugin/src/Elements/Db/EventQuery.php
@@ -428,9 +428,10 @@ class EventQuery extends ElementQuery implements \Countable
     /**
      * @param string $q
      * @param null   $db
+     *
+     * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count($q = '*', $db = null): int
+    public function count($q = '*', $db = null)
     {
         $this->all($db);
 

--- a/packages/plugin/src/Elements/Db/EventQuery.php
+++ b/packages/plugin/src/Elements/Db/EventQuery.php
@@ -429,6 +429,7 @@ class EventQuery extends ElementQuery implements \Countable
      * @param string $q
      * @param null   $db
      */
+    #[\ReturnTypeWillChange]
     public function count($q = '*', $db = null): int
     {
         $this->all($db);


### PR DESCRIPTION
Fixes the following PHP 8.1 error:

```During inheritance of Countable: Uncaught yii\base\ErrorException: Return type of yii\db\QueryInterface::count($q = '*', $db = null) should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/user/vendor/yiisoft/yii2/db/QueryInterface.php:49```